### PR TITLE
Switch calendar and map to the Google Calendar feed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -364,3 +364,6 @@ $RECYCLE.BIN/
 *.lnk
 
 # End of https://www.toptal.com/developers/gitignore/api/visualstudiocode,jetbrains,jetbrains+all,adobe,macos,linux,windows,webstorm,git
+.claude/
+
+cloudflare/ics-proxy/.wrangler/

--- a/assets/css/leistungstag.css
+++ b/assets/css/leistungstag.css
@@ -10,3 +10,11 @@
 #language {
     width: 10rem;
 }
+
+/* Google's calendar embed has no dark skin and always paints itself white,
+   which the rest of the site is not. Inverting the iframe matches the dark
+   template; the hue-rotate puts the colours (links, event dots) back. */
+#google-calendar {
+    filter: invert(1) hue-rotate(180deg);
+    border-radius: 4px;
+}

--- a/cloudflare/ics-proxy/README.md
+++ b/cloudflare/ics-proxy/README.md
@@ -1,0 +1,55 @@
+# ics.leistungstag.beer
+
+Cloudflare Worker that serves the public Google Calendar ICS feed
+(`leistungstag@gmail.com`) under our own domain.
+
+Proxy instead of a 301/302 redirect, because:
+
+- browsers drop CORS on cross-origin redirects, and the site fetches the feed
+  with `fetch()` — Google's ICS endpoint sends no `Access-Control-Allow-Origin`
+- the URL stays ours if the calendar backend changes again
+- Google names the feed after the account, so subscribers would see
+  `leistungstag@gmail.com` in their calendar list; the Worker rewrites it
+
+## `?locationAsCoords=true`
+
+The Leistungskarte needs `LOCATION` to be `"<lat> <lng>"`, which is what the old
+Leistungsbot feed emitted. Google Calendar stores postal addresses instead, so
+the Worker geocodes them via [Nominatim](https://nominatim.openstreetmap.org)
+and caches the results in KV under a single `geocache:v1` key.
+
+Lookups never block a response: misses are geocoded in `waitUntil` (3 per
+request) and by a nightly cron (40 per run), so a new venue appears on the map
+within a few page loads at worst. Events whose address is not resolved yet are
+served without a `LOCATION` and skipped by `map.js` — no `NaN` markers.
+
+Nominatim's usage policy is respected: identifying `User-Agent`, at most one
+request per second, and cached results so the steady state costs no lookups.
+
+## Deploy
+
+```sh
+npx wrangler login                      # once
+npx wrangler kv namespace create GEOCACHE
+```
+
+Put the printed id into `kv_namespaces[0].id` in `wrangler.jsonc`, then:
+
+```sh
+npx wrangler deploy                     # from this directory
+```
+
+`wrangler.jsonc` claims `ics.leistungstag.beer` as a Workers custom domain,
+which replaces the existing DNS record for that hostname.
+
+## Verify
+
+```sh
+curl -sI https://ics.leistungstag.beer | grep -i 'access-control\|content-type'
+curl -s https://ics.leistungstag.beer | head -5
+curl -s 'https://ics.leistungstag.beer/?locationAsCoords=true' | grep -m3 '^LOCATION:'
+```
+
+The last command should print coordinate pairs. Right after the first deploy the
+cache is empty, so give the cron a night — or hit the URL a few dozen times — to
+fill it.

--- a/cloudflare/ics-proxy/src/index.js
+++ b/cloudflare/ics-proxy/src/index.js
@@ -1,0 +1,254 @@
+const UPSTREAM =
+	"https://calendar.google.com/calendar/ical/leistungstag%40gmail.com/public/basic.ics";
+
+const CORS = {
+	"Access-Control-Allow-Origin": "*",
+	"Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
+	"Access-Control-Max-Age": "86400",
+};
+
+const FEED_HEADERS = {
+	...CORS,
+	"Content-Type": "text/calendar; charset=utf-8",
+	"Content-Disposition": 'inline; filename="leistungstag.ics"',
+	"Cache-Control": "public, max-age=300",
+};
+
+// Nominatim asks for a User-Agent that identifies the application and for at
+// most one request per second. Both are honoured below; results are cached in
+// KV so a steady state costs zero upstream lookups.
+const NOMINATIM = "https://nominatim.openstreetmap.org/search";
+const USER_AGENT = "leistungstag.beer ICS proxy (https://www.leistungstag.beer)";
+const GEOCODE_DELAY_MS = 1100;
+
+const GEOCACHE_KEY = "geocache:v1";
+// Kept small: this runs in waitUntil after the response is already sent, and a
+// handful of page loads is enough to fill the cache for a new venue.
+const LOOKUPS_PER_REQUEST = 3;
+const LOOKUPS_PER_CRON = 40;
+// An address that Nominatim cannot resolve is usually a typo in the calendar
+// entry, so back off instead of retrying it on every single request.
+const NEGATIVE_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+
+export default {
+	async fetch(request, env, ctx) {
+		if (request.method === "OPTIONS") {
+			return new Response(null, { status: 204, headers: CORS });
+		}
+
+		if (request.method !== "GET" && request.method !== "HEAD") {
+			return new Response("Method Not Allowed", {
+				status: 405,
+				headers: { ...CORS, Allow: "GET, HEAD, OPTIONS" },
+			});
+		}
+
+		const upstream = await fetchUpstream();
+		if (!upstream.ok) {
+			return new Response("Upstream calendar unavailable", {
+				status: 502,
+				headers: { ...CORS, "Content-Type": "text/plain; charset=utf-8" },
+			});
+		}
+
+		const asCoords =
+			new URL(request.url).searchParams.get("locationAsCoords") === "true";
+
+		if (asCoords && !env.GEOCACHE) {
+			return new Response(
+				"locationAsCoords needs the GEOCACHE KV namespace; see cloudflare/ics-proxy/README.md",
+				{
+					status: 503,
+					headers: { ...CORS, "Content-Type": "text/plain; charset=utf-8" },
+				},
+			);
+		}
+
+		if (request.method === "HEAD") {
+			return new Response(null, { status: 200, headers: FEED_HEADERS });
+		}
+
+		let feed = rename(await upstream.text());
+
+		if (asCoords) {
+			const cache = await readCache(env);
+			// Collect the misses before rewriting: withCoordinates strips the
+			// LOCATION of everything it cannot resolve, so afterwards there is
+			// nothing left to look up.
+			const missing = unresolved(feed, cache);
+			feed = withCoordinates(feed, cache);
+
+			if (missing.length > 0) {
+				ctx.waitUntil(fillCache(env, missing.slice(0, LOOKUPS_PER_REQUEST)));
+			}
+		}
+
+		return new Response(feed, { status: 200, headers: FEED_HEADERS });
+	},
+
+	// Keeps the geocode cache warm so a freshly added venue shows up on the map
+	// without waiting for enough page loads to trickle through waitUntil.
+	async scheduled(event, env, ctx) {
+		if (!env.GEOCACHE) return;
+
+		ctx.waitUntil(
+			(async () => {
+				const upstream = await fetchUpstream();
+				if (!upstream.ok) return;
+
+				const cache = await readCache(env);
+				const missing = unresolved(await upstream.text(), cache);
+				if (missing.length > 0) {
+					await fillCache(env, missing.slice(0, LOOKUPS_PER_CRON));
+				}
+			})(),
+		);
+	},
+};
+
+function fetchUpstream() {
+	// Google sends no-store; cache at the edge so calendar clients that poll
+	// often do not hammer upstream.
+	return fetch(UPSTREAM, { cf: { cacheTtl: 300, cacheEverything: true } });
+}
+
+// Google names the feed after the account, so subscribers would otherwise see
+// "leistungstag@gmail.com" in their calendar list.
+function rename(feed) {
+	return feed
+		.replace(/^X-WR-CALNAME:.*$/m, "X-WR-CALNAME:Leistungstag")
+		.replace(/^X-WR-CALNAME:/m, "NAME:Leistungstag\r\nX-WR-CALNAME:");
+}
+
+/* -------------------------------------------------------------------------- */
+/* ICS text handling                                                          */
+/* -------------------------------------------------------------------------- */
+
+function unfold(feed) {
+	return feed.replace(/\r\n/g, "\n").replace(/\n[ \t]/g, "");
+}
+
+function fold(line) {
+	const bytes = new TextEncoder().encode(line);
+	if (bytes.length <= 75) return line;
+
+	const decoder = new TextDecoder();
+	const chunks = [];
+	let start = 0;
+	// Continuation lines spend one octet on their leading space.
+	let limit = 75;
+
+	while (start < bytes.length) {
+		let end = Math.min(start + limit, bytes.length);
+		// Never cut a UTF-8 sequence in half.
+		while (end > start && end < bytes.length && (bytes[end] & 0xc0) === 0x80) {
+			end--;
+		}
+		chunks.push(decoder.decode(bytes.slice(start, end)));
+		start = end;
+		limit = 74;
+	}
+
+	return chunks.join("\r\n ");
+}
+
+function unescapeIcsText(value) {
+	return value
+		.replace(/\\n/gi, "\n")
+		.replace(/\\([,;\\])/g, "$1")
+		.trim();
+}
+
+function locationOf(line) {
+	const match = line.match(/^LOCATION(?:;[^:]*)?:(.*)$/);
+	return match ? unescapeIcsText(match[1]) : null;
+}
+
+/**
+ * Rewrites every LOCATION to "<lat> <lng>", which is the shape the map on
+ * leistungstag.beer expects. Addresses that are not in the cache yet lose their
+ * LOCATION entirely — the map skips those events rather than plotting NaN.
+ */
+function withCoordinates(feed, cache) {
+	return unfold(feed)
+		.split("\n")
+		.map((line) => {
+			const address = locationOf(line);
+			if (address === null) return fold(line);
+
+			const hit = cache[address];
+			if (!hit || typeof hit.lat !== "number") return null;
+
+			return `LOCATION:${hit.lat} ${hit.lon}`;
+		})
+		.filter((line) => line !== null)
+		.join("\r\n");
+}
+
+function addressesIn(feed) {
+	const seen = new Set();
+	for (const line of unfold(feed).split("\n")) {
+		const address = locationOf(line);
+		if (address) seen.add(address);
+	}
+	return [...seen];
+}
+
+function unresolved(feed, cache) {
+	const now = Date.now();
+	return addressesIn(feed).filter((address) => {
+		const hit = cache[address];
+		if (!hit) return true;
+		if (typeof hit.lat === "number") return false;
+		return now - (hit.failedAt ?? 0) > NEGATIVE_TTL_MS;
+	});
+}
+
+/* -------------------------------------------------------------------------- */
+/* Geocoding                                                                  */
+/* -------------------------------------------------------------------------- */
+
+async function readCache(env) {
+	return (await env.GEOCACHE.get(GEOCACHE_KEY, "json")) ?? {};
+}
+
+async function fillCache(env, addresses) {
+	const resolved = {};
+
+	for (const [index, address] of addresses.entries()) {
+		if (index > 0) await sleep(GEOCODE_DELAY_MS);
+		const hit = await geocode(address);
+		resolved[address] = hit ?? { failedAt: Date.now() };
+	}
+
+	// Re-read rather than reusing the snapshot the request started with, so a
+	// concurrent fill of a different address is not thrown away.
+	const cache = await readCache(env);
+	await env.GEOCACHE.put(
+		GEOCACHE_KEY,
+		JSON.stringify({ ...cache, ...resolved }),
+	);
+}
+
+async function geocode(address) {
+	const url = new URL(NOMINATIM);
+	url.searchParams.set("format", "jsonv2");
+	url.searchParams.set("limit", "1");
+	url.searchParams.set("q", address);
+
+	const response = await fetch(url, {
+		headers: { "User-Agent": USER_AGENT, "Accept-Language": "de" },
+	});
+	if (!response.ok) return null;
+
+	const hits = await response.json();
+	if (!Array.isArray(hits) || hits.length === 0) return null;
+
+	const lat = Number.parseFloat(hits[0].lat);
+	const lon = Number.parseFloat(hits[0].lon);
+	return Number.isFinite(lat) && Number.isFinite(lon) ? { lat, lon } : null;
+}
+
+function sleep(ms) {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/cloudflare/ics-proxy/wrangler.jsonc
+++ b/cloudflare/ics-proxy/wrangler.jsonc
@@ -1,0 +1,28 @@
+{
+	"$schema": "node_modules/wrangler/config-schema.json",
+	"name": "leistungstag-ics",
+	"main": "src/index.js",
+	"compatibility_date": "2026-08-04",
+	"observability": {
+		"enabled": true
+	},
+	"routes": [
+		{
+			"pattern": "ics.leistungstag.beer",
+			"custom_domain": true
+		}
+	],
+	"kv_namespaces": [
+		{
+			"binding": "GEOCACHE",
+			// Replace with the id printed by:
+			//   npx wrangler kv namespace create GEOCACHE
+			"id": "REPLACE_ME"
+		}
+	],
+	"triggers": {
+		// Nightly warm-up so a newly added venue reaches the map even if nobody
+		// loads the site in the meantime.
+		"crons": ["17 4 * * *"]
+	}
+}

--- a/index.html
+++ b/index.html
@@ -93,11 +93,10 @@
 		<!-- Work -->
 		<article id="kalender">
 			<h2 class="major">Kalender</h2>
-			<iframe id="open-web-calendar"
-					style="background:url('https://raw.githubusercontent.com/niccokunzmann/open-web-calendar/master/static/img/loaders/circular-loader.gif') center center no-repeat;"
-					src="https://open-web-calendar.hosted.quelltext.eu/calendar.html?controls=next&amp;controls=previous&amp;controls=date&amp;language=de&amp;prefer_browser_language=true&amp;skin=dark&amp;tab=agenda&amp;tabs=month&amp;tabs=agenda&amp;target=_blank&amp;title=Leistungstag%20Kalender&amp;url=https%3A%2F%2Fics.leistungstag.beer%2F"
-					sandbox="allow-scripts allow-same-origin allow-popups"
-					allowTransparency="true" height="600px" width="100%"></iframe>
+			<iframe id="google-calendar"
+					title="Leistungstag Kalender"
+					src="https://calendar.google.com/calendar/embed?src=leistungstag%40gmail.com&amp;ctz=Europe%2FVienna&amp;hl=de&amp;mode=AGENDA&amp;wkst=2&amp;showTitle=0&amp;showPrint=0&amp;showCalendars=0&amp;showTz=0"
+					height="600px" width="100%" frameborder="0" scrolling="no"></iframe>
 		</article>
 		<!-- map -->
 		<article id="leistungskarte">
@@ -110,7 +109,7 @@
 		<article id="ueber">
 			<h2 class="major">Oft gefragte Fragen</h2>
 			<h3>Wie füge ich den Leistungstag Kalender meinem privaten Kalender hinzu?</h3>
-			Klick einfach auf das Plus rechts unten im <a href="#kalender">Kalender</a> oder nutz "https://ics.leistungstag.beer" falls du nicht so ein Google Freund bist.
+			Mit Google: <a href="https://calendar.google.com/calendar/render?cid=leistungstag%40gmail.com" target="_blank" rel="noopener">Leistungstag Kalender abonnieren</a>. Falls du nicht so ein Google Freund bist, abonnier "https://ics.leistungstag.beer" in deiner Kalender-App.
 			<h3>Was ist der Zweck dieses Vereins?</h3>
 			Der Verein wurde gegründet, um wöchentlich in verschiedenen Lokalen zusammenzukommen, Spaß zu haben und die Vielfalt der örtlichen Gastronomieszene zu erkunden.
 			<h3>Wie oft findet der Stammtisch statt?</h3>

--- a/map.js
+++ b/map.js
@@ -14,6 +14,17 @@ class LeistungsTypen {
         return 3;
     }
 }
+// Google Calendar prefixes every summary with its category ("Leistungstag:
+// Goethe Stub'n"). The old spellings stay in the list so historic events that
+// were written by Leistungsbot itself still get the right icon. Order matters:
+// the specific categories have to win over the plain "Leistungstag".
+const LEISTUNGSTAG_KATEGORIEN = [
+    [/^Konkurrenz[ -]?Leistungstag:?\s*/i, LeistungsTypen.KONKURRENZLEISTUNGSTAG],
+    [/^(?:Leistungstag Zusatztermin|Zusatzleistungstag):?\s*/i, LeistungsTypen.ZUSATZLEISTUNGSTAG],
+    [/^(?:Jahres|Abschluss)leistungstag:?\s*/i, LeistungsTypen.YEARLY_WINNER],
+    [/^Leistungstag:?\s*/i, LeistungsTypen.LEISTUNGSTAG],
+];
+
 class Leistungstag {
     title;
     date;
@@ -21,20 +32,19 @@ class Leistungstag {
     type;
 
     constructor(title, position, date) {
-        this.title = title;
         this.position = position;
         this.date = date;
-        if(title.startsWith("Konkurrenzleistungstag")) {
-            this.type = LeistungsTypen.KONKURRENZLEISTUNGSTAG
-        }
-        else if(title.startsWith("Zusatzleistungstag")) {
-            this.type = LeistungsTypen.ZUSATZLEISTUNGSTAG
-        }
-	else if(title.startsWith("Jahresleistungstag")) {
-            this.type = LeistungsTypen.YEARLY_WINNER
-	}
-        else {
-            this.type = LeistungsTypen.LEISTUNGSTAG
+        this.type = LeistungsTypen.LEISTUNGSTAG;
+        this.title = title;
+
+        for (const [prefix, type] of LEISTUNGSTAG_KATEGORIEN) {
+            if (prefix.test(title)) {
+                // The icon already says which category it is, so the popup only
+                // needs the name of the Lokal.
+                this.title = title.replace(prefix, "");
+                this.type = type;
+                break;
+            }
         }
     }
 }
@@ -50,11 +60,18 @@ async function getLeistungstage() {
         .then(async response => ICAL.parse(await response.text()))
     const vCalendar = new ICAL.Component(data);
     return vCalendar.getAllSubcomponents("vevent").map(event => {
+        // The proxy drops LOCATION for venues it has not geocoded yet, so an
+        // event without usable coordinates is expected rather than an error.
+        let location = event.getFirstPropertyValue("location")
+        if (!location) return null
+
+        let [lat, lng] = location.split(" ").map(value => parseFloat(value))
+        if (!Number.isFinite(lat) || !Number.isFinite(lng)) return null
+
         let name = event.getFirstPropertyValue("summary")
-        let latLng = event.getFirstPropertyValue("location").split(" ")
         let date = event.getFirstPropertyValue("dtstart").toJSDate()
-        return new Leistungstag(name, [parseFloat(latLng[0]), parseFloat(latLng[1])], date)
-    });
+        return new Leistungstag(name, [lat, lng], date)
+    }).filter(leistungstag => leistungstag !== null);
 }
 
 async function initMap() {


### PR DESCRIPTION
Leistungsbot now writes events to Google Calendar, so the site and `ics.leistungstag.beer` have to read from there.

## What changed

**`cloudflare/ics-proxy/` — the Worker behind `ics.leistungstag.beer`**

Proxies the Google feed instead of redirecting to it: browsers drop CORS across cross-origin redirects and Google's ICS endpoint sends no `Access-Control-Allow-Origin`, so a redirect would break the site's own map. It also renames the feed, which Google otherwise labels `leistungstag@gmail.com` in subscribers' calendar lists.

**The Leistungskarte was broken by the switch, and is fixed here**

`map.js` expects `LOCATION` to be `"<lat> <lng>"` — what the old Leistungsbot feed emitted. Google Calendar stores postal addresses (`LOCATION:Dinghoferstraße 52\, 4020 Linz\, Österreich`, 0 `GEO` properties across all 257 events), so `parseFloat("Dinghoferstraße")` was `NaN` and every marker was dropped.

The Worker now answers `?locationAsCoords=true` by geocoding addresses through Nominatim and caching them in KV, which keeps the contract `map.js` already relied on. Lookups never block a response — misses are resolved in `waitUntil` (3/request) and by a nightly cron (40/run), so a new venue reaches the map within a few page loads. Events not yet geocoded are served without a `LOCATION` and skipped by `map.js` rather than plotted at `NaN`. Nominatim's policy is respected: identifying `User-Agent`, ≤1 req/s, cached so the steady state costs no lookups.

Google also renamed the summary prefixes — `Leistungstag Zusatztermin:` instead of `Zusatzleistungstag`, `Konkurrenz Leistungstag:` instead of `Konkurrenzleistungstag` — which silently downgraded all 23 Zusatz-/Konkurrenzleistungstage to the default icon. The prefixes are now a table that keeps the old spellings for historic events and strips the category from the popup title, since the icon already conveys it.

**The calendar widget**

Replaces the open-web-calendar iframe with Google's own embed. It cannot be themed and always paints itself white, so the iframe is inverted back into the dark template. `loading="lazy"` is deliberately absent — the article is hidden until the nav opens it, and a lazy iframe inside it never issues a request at all (this was the blank calendar).

## Before this merges

The Worker needs a KV namespace, which I could not create:

```sh
cd cloudflare/ics-proxy
npx wrangler kv namespace create GEOCACHE   # put the id into wrangler.jsonc
npx wrangler deploy
```

Until it is deployed, the currently-live Worker keeps serving addresses and the map renders empty — no errors, just no markers.

## Verification

The Worker was run end-to-end in Node against the real Google feed with an in-memory KV:

- plain feed: `200`, `text/calendar`, `Access-Control-Allow-Origin: *`, `NAME:Leistungstag`
- cold cache: 257 VEVENTs preserved, 0 `LOCATION` lines, one fill queued — 3 addresses geocoded for real
- warm cache: 257 `LOCATION` lines, all coordinate-shaped, CRLF-only, max line 75 octets (folding correct), `BEGIN`/`END:VEVENT` balanced
- `HEAD` 200 · `OPTIONS` 204 · `POST` 405 · missing KV binding 503

In the browser against that output: 257 markers, 0 invalid positions, icons split 234 Leistungstag / 17 Zusatz / 6 Konkurrenz — matching the feed exactly — and titles de-prefixed. Against the current live feed: 0 markers and no console errors, confirming the graceful path. Calendar checked at desktop and 375px.

> [!NOTE]
> `origin/google-calendar-ics` carries an earlier attempt at this on a `public-html/` layout that predates 45 commits on `main`. This branch supersedes it; that one can be closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)